### PR TITLE
Fix: Don't reload ```searchList``` entries when ```options``` is set in config

### DIFF
--- a/js/content/searchList.ts
+++ b/js/content/searchList.ts
@@ -227,15 +227,16 @@ export default {
 			dt.ready(() => {
 				reloadOptions(dt, config, this.idx(), checkList, loadedValues);
 			});
+
+			// Xhr event listener for updates of options
+			dt.on('xhr', (e, s, json) => {
+				// Need to wait for the draw to complete so the table has the latest data
+				dt.one('draw', () => {
+					reloadOptions(dt, config, this.idx(), checkList, loadedValues);
+				});
+			});
 		}
 
-		// Xhr event listener for updates of options
-		dt.on('xhr', (e, s, json) => {
-			// Need to wait for the draw to complete so the table has the latest data
-			dt.one('draw', () => {
-				reloadOptions(dt, config, this.idx(), checkList, loadedValues);
-			});
-		});
 
 		// Unlike the SearchInput based search contents, CheckList does not handle state saving
 		// (since the mechanism for column visibility is different), so state saving is handled


### PR DESCRIPTION
## First Contribution – Improving `searchList.config.options` Behavior

Hi there! 👋
This is my first contribution to a project – I hope I'm doing it right!

#### Specification

You can specify a list of options to be used for the toggle buttons via `searchList.config.options`:

```js
searchList.config.options = [
  { label: "Label 1", value: "value1" },
  { label: "Label 2", value: "value2" },
  // ...
];
```

This should override automatically determined options and those fetched via Ajax.

However, based on my understanding and the behavior shown in this [[JSFiddle example](https://jsfiddle.net/hz8ygoa0/58/)](https://jsfiddle.net/hz8ygoa0/58/), the manually defined options are still being overridden by automatic retrieval — regardless of whether `ajaxOnly` is set to `true` or `false`.

### Proposed Change

I suggest that when `searchList.config.options` is explicitly set, it should **take precedence** and **prevent options from being reloaded** automatically or via Ajax.

### Thanks!

Thank you for reviewing this!
Let me know if anything needs to be changed or improved.

---

I acknowledge that my contribution is offered under and will be made available under the project's existing license (MIT). ✅